### PR TITLE
Update netclient.rb

### DIFF
--- a/Casks/netclient.rb
+++ b/Casks/netclient.rb
@@ -3,9 +3,9 @@ cask "netclient" do
   version "0.14.2"
 
   if Hardware::CPU.intel?
-    sha256 6e2f1731cd7d2ab47a00ad958e5e0301d5e074d4a53e48b4c1586d8b2007f26f
+    sha256 "6e2f1731cd7d2ab47a00ad958e5e0301d5e074d4a53e48b4c1586d8b2007f26f"
   else
-    sha256 98855f5aad663f9f0bba1d994012274f7f58e09813839685dc5c43542f3ec97c
+    sha256 "98855f5aad663f9f0bba1d994012274f7f58e09813839685dc5c43542f3ec97c"
   end
 
   url "https://github.com/gravitl/homebrew-netclient/releases/download/v#{version}/netclient-#{arch}.tgz"


### PR DESCRIPTION
This fixes a syntax error I encountered when running `brew tap gravitl/netclient`:

```==> Tapping gravitl/netclient
Cloning into '/opt/homebrew/Library/Taps/gravitl/homebrew-netclient'...
remote: Enumerating objects: 215, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 215 (delta 2), reused 2 (delta 0), pack-reused 204
Receiving objects: 100% (215/215), 33.16 MiB | 5.70 MiB/s, done.
Resolving deltas: 100% (68/68), done.
Error: Invalid cask: /opt/homebrew/Library/Taps/gravitl/homebrew-netclient/Casks/netclient.rb
Cask 'netclient' is unreadable: /opt/homebrew/Library/Taps/gravitl/homebrew-netclient/Casks/netclient.rb:6: syntax error, unexpected tIDENTIFIER, expecting end
...5e074d4a53e48b4c1586d8b2007f26f
...^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/Library/Taps/gravitl/homebrew-netclient/Casks/netclient.rb:8: syntax error, unexpected tIDENTIFIER, expecting end
...f58e09813839685dc5c43542f3ec97c
...^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Error: Cannot tap gravitl/netclient: invalid syntax in tap!```